### PR TITLE
fix: replace deprecated Element.isSynthetic with isOriginDeclaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - 2026-05-23
 
 ### Changed (Breaking)
-- **Minimum `analyzer` version raised to `^10.0.0`.** The package now uses the canonical (unsuffixed) Element API — `ClassElement`, `FieldElement`, `ConstructorElement`, `.fields`, `.constructors`, `.element` — instead of the transitional `Element2` / `element3` / `fields2` / `constructors2` APIs that have been removed in modern analyzer releases. Downstream projects pinned to older `analyzer` versions must upgrade.
-- **Minimum SDK constraints raised** to Dart `^3.11.0` and Flutter `>=3.41.0` to match current stable Flutter releases.
+- **Minimum `analyzer` version raised to `^10.0.0`.** The package now uses the canonical (unsuffixed) Element API — `ClassElement`, `FieldElement`, `ConstructorElement`, `.fields`, `.constructors`, `.element` — instead of the transitional `Element2` / `element3` / `fields2` / `constructors2` APIs that have been removed in modern analyzer releases. Field filtering also switched from the deprecated `Element.isSynthetic` getter to the fine-grained `isOriginDeclaration` predicate, eliminating `deprecated_member_use` warnings that would otherwise surface in consumer editors on analyzer 13. Downstream projects pinned to older `analyzer` versions must upgrade.
+- **Minimum SDK constraint raised** to Dart `^3.11.0`. Flutter is no longer a required SDK — the package is pure Dart and works in Flutter, Dart server-side, and CLI projects alike.
 - **`source_gen` and `build` constraints widened** (`>=3.1.0 <5.0.0` and `>=3.0.0 <5.0.0` respectively) so the package can resolve alongside modern build tooling and analyzer-coupled linters such as `bloc_lint`.
 
 ### Fixed

--- a/lib/src/builders/entity_mapper_generator.dart
+++ b/lib/src/builders/entity_mapper_generator.dart
@@ -83,10 +83,10 @@ class EntityMapperGenerator extends Generator {
     final mapperBaseName = _getEntityTypeFromModelType(className);
     final entityVariableName = _camelCase(mapperBaseName);
     final modelFields = element.fields
-        .where((f) => !f.isStatic && !f.isSynthetic)
+        .where((f) => !f.isStatic && f.isOriginDeclaration)
         .toList();
     final entityFields = entityElement.fields
-        .where((f) => !f.isStatic && !f.isSynthetic)
+        .where((f) => !f.isStatic && f.isOriginDeclaration)
         .toList();
     final modelFieldNames = modelFields.map((f) => f.displayName).toSet();
     final entityFieldNames = entityFields.map((f) => f.displayName).toSet();
@@ -493,20 +493,4 @@ class EntityMapperGenerator extends Generator {
     // Case 3: primitive / non-mappable — direct.
     return 'model.$fieldName';
   }
-}
-
-/// Polyfill `isSynthetic` for `Element` so the generator compiles against
-/// both analyzer 10.x (where `Element.isSynthetic` is a direct getter) and
-/// analyzer 13.x (which removed the getter in favor of `nonSynthetic`).
-///
-/// Semantics in analyzer 13: `element.nonSynthetic` returns the element
-/// itself if it is not synthetic, otherwise returns the source element that
-/// caused this synthetic element to be created. So an element is synthetic
-/// when it differs from its own `nonSynthetic`.
-///
-/// When analyzer 10's instance `isSynthetic` is in scope it shadows this
-/// extension automatically (instance members win over extension members),
-/// so the polyfill only activates on the newer analyzer.
-extension _SyntheticPolyfill on Element {
-  bool get isSynthetic => !identical(this, nonSynthetic);
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Description

<!--- Describe your changes in detail -->

- Replace deprecated `Element.isSynthetic` getter to the fine-grained `isOriginDeclaration`

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Test
